### PR TITLE
Pin dbt to <1.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/astronomer/astro-runtime:8.8.0
 
 # install dbt into a virtual environment
 RUN python -m venv dbt_venv && source dbt_venv/bin/activate && \
-    pip install --no-cache-dir dbt-postgres && deactivate
+    pip install --no-cache-dir dbt-postgres<1.6 && deactivate
 
 # set a connection to the airflow metadata db to use for testing
 ENV AIRFLOW_CONN_AIRFLOW_METADATA_DB=postgresql+psycopg2://postgres:postgres@postgres:5432/postgres


### PR DESCRIPTION
dbt 1.6 breaks Cosmos and we're still investigating why. This pins the version until we can figure it out 