### PR TITLE
Upgrade project to Astro Runtime 12.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM quay.io/astronomer/astro-runtime:11.3.0
+FROM quay.io/astronomer/astro-runtime:12.1.1
 
 # install dbt into a virtual environment
 RUN python -m venv dbt_venv && source dbt_venv/bin/activate && \
-    pip install --no-cache-dir dbt-postgres==1.5.4 && deactivate
+    pip install --no-cache-dir dbt-postgres==1.8.2 && deactivate
 
 # set a connection to the airflow metadata db to use for testing
 ENV AIRFLOW_CONN_AIRFLOW_METADATA_DB=postgresql+psycopg2://postgres:postgres@postgres:5432/postgres


### PR DESCRIPTION
The project is currently based on Astro Runtime 11.3.0 (which uses Python 3.11), but new deployments are based on Runtime 11.4.0+ (which uses Python 3.12+) and those are not compatible with dbt-postgres 1.5.4 (`distutils` is removed), leading to DAG import errors.

This change fixes it by upgrading to the latest Runtime and dbt-postgres versions.