### PR TITLE
Fix `improper relation name (too many dotted names)` error

### DIFF
--- a/dbt/jaffle_shop/macros/drop_table.sql
+++ b/dbt/jaffle_shop/macros/drop_table.sql
@@ -1,6 +1,0 @@
-{%- macro drop_table(table_name) -%}
-    {%- set drop_query -%}
-        DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }} CASCADE
-    {%- endset -%}
-    {% do run_query(drop_query) %}
-{%- endmacro -%}


### PR DESCRIPTION
When trying to run most example DAGs, or even just running `dbt run`,  we would get an error saying Improper relation name with the latest dbt versions. This was resolved by removing the custom macro.

Error message before:

```
$ dbt run --profile airflow_db 
14:24:46  Running with dbt=1.9.4
14:24:46  Registered adapter: postgres=1.9.0
14:24:46  Found 5 models, 3 seeds, 20 data tests, 434 macros
14:24:46  
14:24:46  Concurrency: 4 threads (target='dev')
14:24:46  
14:24:47  1 of 5 START sql view model public.stg_customers ............................... [RUN]
14:24:47  2 of 5 START sql view model public.stg_orders .................................. [RUN]
14:24:47  3 of 5 START sql view model public.stg_payments ................................ [RUN]
14:24:47  2 of 5 OK created sql view model public.stg_orders ............................. [CREATE VIEW in 0.12s]
14:24:47  1 of 5 OK created sql view model public.stg_customers .......................... [CREATE VIEW in 0.13s]
14:24:47  3 of 5 OK created sql view model public.stg_payments ........................... [CREATE VIEW in 0.13s]
14:24:47  4 of 5 START sql table model public.customers .................................. [RUN]
14:24:47  5 of 5 START sql table model public.orders ..................................... [RUN]
14:24:47  5 of 5 ERROR creating sql table model public.orders ............................ [ERROR in 0.05s]
14:24:47  4 of 5 ERROR creating sql table model public.customers ......................... [ERROR in 0.05s]
14:24:47  
14:24:47  Finished running 2 table models, 3 view models in 0 hours 0 minutes and 0.51 seconds (0.51s).
14:24:47  
14:24:47  Completed with 2 errors, 0 partial successes, and 0 warnings:
14:24:47  
14:24:47    Database Error in model orders (models/orders.sql)
  improper relation name (too many dotted names): public.postgres.public.orders__dbt_backup
14:24:47  
14:24:47    Database Error in model customers (models/customers/customers.sql)
  improper relation name (too many dotted names): public.postgres.public.customers__dbt_backup
14:24:47  
14:24:47  Done. PASS=3 WARN=0 ERROR=2 SKIP=0 TOTAL=5
```

Absence of error after change:

```
$ dbt run --profile airflow_db 
14:30:26  Running with dbt=1.9.4
14:30:26  Registered adapter: postgres=1.9.0
14:30:26  Found 5 models, 3 seeds, 20 data tests, 433 macros
14:30:26  
14:30:26  Concurrency: 4 threads (target='dev')
14:30:26  
14:30:26  1 of 5 START sql view model dbt.stg_customers .................................. [RUN]
14:30:26  2 of 5 START sql view model dbt.stg_orders ..................................... [RUN]
14:30:26  3 of 5 START sql view model dbt.stg_payments ................................... [RUN]
14:30:26  1 of 5 OK created sql view model dbt.stg_customers ............................. [CREATE VIEW in 0.12s]
14:30:26  3 of 5 OK created sql view model dbt.stg_payments .............................. [CREATE VIEW in 0.12s]
14:30:26  2 of 5 OK created sql view model dbt.stg_orders ................................ [CREATE VIEW in 0.12s]
14:30:26  4 of 5 START sql table model dbt.customers ..................................... [RUN]
14:30:26  5 of 5 START sql table model dbt.orders ........................................ [RUN]
14:30:26  4 of 5 OK created sql table model dbt.customers ................................ [SELECT 100 in 0.07s]
14:30:26  5 of 5 OK created sql table model dbt.orders ................................... [SELECT 99 in 0.07s]
14:30:26  
14:30:26  Finished running 2 table models, 3 view models in 0 hours 0 minutes and 0.32 seconds (0.32s).
14:30:26  
14:30:26  Completed successfully
14:30:26  
14:30:26  Done. PASS=5 WARN=0 ERROR=0 SKIP=0 TOTAL=5
```