### PR TITLE
Use latest runtime image and replace schedule_interval with schedule

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/astronomer/astro-runtime:12.1.1
+#FROM quay.io/astronomer/astro-runtime:12.1.1
+FROM astrocrpublic.azurecr.io/runtime:3.1-14
 
 # install dbt into a virtual environment
 RUN python -m venv dbt_venv && source dbt_venv/bin/activate && \

--- a/dags/basic/simple_dag.py
+++ b/dags/basic/simple_dag.py
@@ -11,7 +11,7 @@ simple_dag = DbtDag(
     profile_config=airflow_db,
     execution_config=venv_execution_config,
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="simple_dag",

--- a/dags/basic/simple_task_group.py
+++ b/dags/basic/simple_task_group.py
@@ -11,7 +11,7 @@ from include.constants import jaffle_shop_path, venv_execution_config
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     tags=["simple"],

--- a/dags/filtering/customers_tag.py
+++ b/dags/filtering/customers_tag.py
@@ -14,7 +14,7 @@ customers_tag = DbtDag(
         select=["tag:customers"],
     ),
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="customers_tag",

--- a/dags/filtering/only_models.py
+++ b/dags/filtering/only_models.py
@@ -14,7 +14,7 @@ only_models = DbtDag(
         select=["path:models"],
     ),
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="only_models",

--- a/dags/filtering/only_seeds.py
+++ b/dags/filtering/only_seeds.py
@@ -14,7 +14,7 @@ only_seeds = DbtDag(
         select=["path:seeds"],
     ),
     # normal dag parameters
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="only_seeds",

--- a/dags/profiles/dbt_profile.py
+++ b/dags/profiles/dbt_profile.py
@@ -15,7 +15,7 @@ dbt_profile_example = DbtDag(
     ),
     execution_config=venv_execution_config,
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="dbt_profile_example",

--- a/dags/profiles/overrides.py
+++ b/dags/profiles/overrides.py
@@ -19,7 +19,7 @@ dbt_profile_overrides = DbtDag(
     ),
     execution_config=venv_execution_config,
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="dbt_profile_overrides",


### PR DESCRIPTION
schedule_interval has been removed in AF3

This PR fix error

```
Traceback (most recent call last):
  File "/usr/local/airflow/dags/filtering/only_seeds.py", line 8, in <module>
    only_seeds = DbtDag(
                 ^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cosmos/airflow/dag.py", line 24, in __init__
    DAG.__init__(self, *args, **airflow_kwargs(**kwargs))
TypeError: DAG.__init__() got an unexpected keyword argument 'schedule_interval'
```