### PR TITLE
Add configurable BigQuery dbt profile support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM astrocrpublic.azurecr.io/runtime:3.1-14
 
 # install dbt into a virtual environment
 RUN python -m venv dbt_venv && source dbt_venv/bin/activate && \
-    pip install --no-cache-dir dbt-postgres==1.8.2 && deactivate
+    pip install --no-cache-dir dbt-postgres==1.8.2 dbt-bigquery==1.8.2 && deactivate
 
 # set a connection to the airflow metadata db to use for testing
 ENV AIRFLOW_CONN_AIRFLOW_METADATA_DB=postgresql+psycopg2://postgres:postgres@postgres:5432/postgres

--- a/dbt/jaffle_shop/profiles.yml
+++ b/dbt/jaffle_shop/profiles.yml
@@ -10,3 +10,14 @@ airflow_db:
       dbname: postgres
       schema: dbt
       threads: 4
+
+bigquery:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: service-account
+      project: "{{ env_var('GCP_PROJECT_ID') }}"
+      dataset: "{{ env_var('GCP_BQ_DATASET') }}"
+      keyfile: "{{ env_var('GCP_KEYFILE_PATH') }}"
+      threads: 4

--- a/include/profiles.py
+++ b/include/profiles.py
@@ -1,14 +1,32 @@
 "Contains profile mappings used in the project"
 
+import os
+
 from cosmos import ProfileConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
+DBT_PROFILE = os.getenv("DBT_PROFILE", "postgres")
 
-airflow_db = ProfileConfig(
-    profile_name="airflow_db",
-    target_name="dev",
-    profile_mapping=PostgresUserPasswordProfileMapping(
-        conn_id="airflow_metadata_db",
-        profile_args={"schema": "dbt"},
-    ),
-)
+if DBT_PROFILE == "bigquery":
+    from cosmos.profiles import GoogleCloudServiceAccountDictProfileMapping
+
+    default_profile = ProfileConfig(
+        profile_name="default",
+        target_name="dev",
+        profile_mapping=GoogleCloudServiceAccountDictProfileMapping(
+            conn_id="gcp_gs_conn",
+            profile_args={"dataset": os.environ["GCP_BQ_DATASET"], "project": os.environ["GCP_PROJECT_ID"]},
+        ),
+    )
+else:
+    default_profile = ProfileConfig(
+        profile_name="airflow_db",
+        target_name="dev",
+        profile_mapping=PostgresUserPasswordProfileMapping(
+            conn_id="airflow_metadata_db",
+            profile_args={"schema": "dbt"},
+        ),
+    )
+
+# Keep backward compatibility
+airflow_db = default_profile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-astronomer-cosmos>=1.0.2
+astronomer-cosmos==1.14.0a9
+apache-airflow-providers-google


### PR DESCRIPTION
Support switching between Postgres and BigQuery profiles via the `DBT_PROFILE` environment variable. Install `dbt-bigquery` and `apache-airflow-providers-google`, and use Cosmos
`GoogleCloudServiceAccountDictProfileMapping` for BQ credentials.

To test this locally, I ended up setting the following envvars in the `.env`:

```
DBT_PROFILE=bigquery
GCP_PROJECT_ID=(...)
GCP_BQ_DATASET=(...)
AIRFLOW_CONN_GCP_GS_CONN=(...)
```